### PR TITLE
feat(ffi): add Imported playlist on file import

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1108,10 +1108,10 @@ impl TornadeCli {
         );
         println!("{}", "-".repeat(80));
 
-        for (pos, track_id) in playlist.tracks.iter().enumerate() {
+        for (pos, pt) in playlist.tracks.iter().enumerate() {
             // Fetch track details
             let conn = self.pool.get()?;
-            if let Ok(Some(track)) = crate::db::queries::get_track(&conn, *track_id) {
+            if let Ok(Some(track)) = crate::db::queries::get_track(&conn, pt.track_id) {
                 println!(
                     "{:<6} {:<6} {:<40} {:<25}",
                     pos,
@@ -1127,9 +1127,10 @@ impl TornadeCli {
         // Option to play playlist
         let choice = Self::read_input("\nPlay playlist? (y/n): ")?;
         if choice.trim().to_lowercase() == "y" {
-            self.player.set_queue(playlist.tracks.clone())?;
-            if !playlist.tracks.is_empty() {
-                self.player.play(playlist.tracks[0])?;
+            let track_ids: Vec<i64> = playlist.tracks.iter().map(|pt| pt.track_id).collect();
+            self.player.set_queue(track_ids.clone())?;
+            if !track_ids.is_empty() {
+                self.player.play(track_ids[0])?;
                 println!("▶️  Playing playlist");
             }
         }

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -435,25 +435,20 @@ fn apply_migration_10_logic(conn: &Connection) -> Result<()> {
     };
 
     for (track_id, title) in tracks {
-        let feat_artists =
-            crate::services::library::extract_feat_from_title(&title);
+        let feat_artists = crate::services::library::extract_feat_from_title(&title);
 
         for name in feat_artists {
             // Find or create the artist row.
-            let artist_id: i64 = match conn.query_row(
-                "SELECT id FROM artists WHERE name = ?1",
-                [&name],
-                |r| r.get(0),
-            ) {
-                Ok(id) => id,
-                Err(_) => {
-                    conn.execute(
-                        "INSERT INTO artists (name) VALUES (?1)",
-                        [&name],
-                    )?;
-                    conn.last_insert_rowid()
-                }
-            };
+            let artist_id: i64 =
+                match conn.query_row("SELECT id FROM artists WHERE name = ?1", [&name], |r| {
+                    r.get(0)
+                }) {
+                    Ok(id) => id,
+                    Err(_) => {
+                        conn.execute("INSERT INTO artists (name) VALUES (?1)", [&name])?;
+                        conn.last_insert_rowid()
+                    }
+                };
 
             // INSERT OR IGNORE: primary key is (track_id, artist_id), so if the artist
             // was already linked via the ARTIST tag, this is a no-op.
@@ -1377,10 +1372,18 @@ mod tests {
 
         // Track must point to primary artist
         let track_artist: i64 = conn
-            .query_row("SELECT artist_id FROM tracks WHERE id = ?1", [track_id], |r| r.get(0))
+            .query_row(
+                "SELECT artist_id FROM tracks WHERE id = ?1",
+                [track_id],
+                |r| r.get(0),
+            )
             .unwrap();
         let primary_id: i64 = conn
-            .query_row("SELECT id FROM artists WHERE name = 'Doc Gynéco'", [], |r| r.get(0))
+            .query_row(
+                "SELECT id FROM artists WHERE name = 'Doc Gynéco'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(track_artist, primary_id);
     }
@@ -1405,23 +1408,48 @@ mod tests {
         // artist1 has 2 tracks, artist2 has 1 → artist1 is dominant
         for path in ["/t1.flac", "/t2.flac"] {
             queries::insert_track(
-                &conn, "T", Some(album), artist1, source,
-                &PathBuf::from(path), 60_000, None, None, None,
-                AudioFormat::Flac, 1_000_000,
-            ).unwrap();
+                &conn,
+                "T",
+                Some(album),
+                artist1,
+                source,
+                &PathBuf::from(path),
+                60_000,
+                None,
+                None,
+                None,
+                AudioFormat::Flac,
+                1_000_000,
+            )
+            .unwrap();
         }
         queries::insert_track(
-            &conn, "T3", Some(album), artist2, source,
-            &PathBuf::from("/t3.flac"), 60_000, None, None, None,
-            AudioFormat::Flac, 1_000_000,
-        ).unwrap();
+            &conn,
+            "T3",
+            Some(album),
+            artist2,
+            source,
+            &PathBuf::from("/t3.flac"),
+            60_000,
+            None,
+            None,
+            None,
+            AudioFormat::Flac,
+            1_000_000,
+        )
+        .unwrap();
 
         apply_migration_9_logic_test(&conn);
 
         let album_artist: i64 = conn
-            .query_row("SELECT artist_id FROM albums WHERE id = ?1", [album], |r| r.get(0))
+            .query_row("SELECT artist_id FROM albums WHERE id = ?1", [album], |r| {
+                r.get(0)
+            })
             .unwrap();
-        assert_eq!(album_artist, artist1, "dominant artist must become the album artist");
+        assert_eq!(
+            album_artist, artist1,
+            "dominant artist must become the album artist"
+        );
     }
 
     #[test]
@@ -1434,15 +1462,29 @@ mod tests {
         let artist = queries::insert_artist(&conn, "Oxmo Puccino", None).unwrap();
         let album = queries::insert_album(&conn, "Mix", va_id, None).unwrap();
         queries::insert_track(
-            &conn, "T", Some(album), artist, source,
-            &PathBuf::from("/t.flac"), 60_000, None, None, None,
-            AudioFormat::Flac, 1_000_000,
-        ).unwrap();
+            &conn,
+            "T",
+            Some(album),
+            artist,
+            source,
+            &PathBuf::from("/t.flac"),
+            60_000,
+            None,
+            None,
+            None,
+            AudioFormat::Flac,
+            1_000_000,
+        )
+        .unwrap();
 
         apply_migration_9_logic_test(&conn);
 
         let va_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM artists WHERE name = 'Various Artists'", [], |r| r.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM artists WHERE name = 'Various Artists'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(va_count, 0, "Various Artists artist must be deleted");
     }
@@ -1455,10 +1497,20 @@ mod tests {
         let artist = queries::insert_artist(&conn, "Adele", None).unwrap();
         let album = queries::insert_album(&conn, "21", artist, None).unwrap();
         queries::insert_track(
-            &conn, "T", Some(album), artist, source,
-            &PathBuf::from("/t.flac"), 60_000, None, None, None,
-            AudioFormat::Flac, 1_000_000,
-        ).unwrap();
+            &conn,
+            "T",
+            Some(album),
+            artist,
+            source,
+            &PathBuf::from("/t.flac"),
+            60_000,
+            None,
+            None,
+            None,
+            AudioFormat::Flac,
+            1_000_000,
+        )
+        .unwrap();
 
         // Must not panic
         apply_migration_9_logic_test(&conn);
@@ -1485,9 +1537,8 @@ mod tests {
 
     #[test]
     fn test_extract_feat_from_title_multiple_artists_ampersand() {
-        let result = crate::services::library::extract_feat_from_title(
-            "Avf (avec OrelSan & Maitre Gims)",
-        );
+        let result =
+            crate::services::library::extract_feat_from_title("Avf (avec OrelSan & Maitre Gims)");
         assert_eq!(result, vec!["OrelSan", "Maitre Gims"]);
     }
 
@@ -1499,8 +1550,7 @@ mod tests {
 
     #[test]
     fn test_extract_feat_from_title_case_insensitive() {
-        let result =
-            crate::services::library::extract_feat_from_title("Track (FEAT. Artist Name)");
+        let result = crate::services::library::extract_feat_from_title("Track (FEAT. Artist Name)");
         assert_eq!(result, vec!["Artist Name"]);
     }
 
@@ -1538,11 +1588,9 @@ mod tests {
 
         // Sia must now exist as an artist
         let sia_id: Option<i64> = conn
-            .query_row(
-                "SELECT id FROM artists WHERE name = 'Sia'",
-                [],
-                |r| r.get(0),
-            )
+            .query_row("SELECT id FROM artists WHERE name = 'Sia'", [], |r| {
+                r.get(0)
+            })
             .optional()
             .unwrap();
         assert!(sia_id.is_some(), "Sia must be created as an artist");

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -98,7 +98,8 @@ pub fn insert_artist(conn: &Connection, name: &str, name_sort: Option<&str>) -> 
 pub fn get_artist(conn: &Connection, id: i64) -> Result<Option<Artist>> {
     conn.query_row(
         "SELECT id, name, name_sort, bio, country, genre, style, mood,
-                formed_year, born_year, died_year, disbanded, musicbrainz_id, theaudiodb_id
+                formed_year, born_year, died_year, disbanded, musicbrainz_id, theaudiodb_id,
+                photo_path
          FROM artists WHERE id = ?1",
         params![id],
         |row| {
@@ -117,6 +118,7 @@ pub fn get_artist(conn: &Connection, id: i64) -> Result<Option<Artist>> {
                 disbanded: row.get(11)?,
                 musicbrainz_id: row.get(12)?,
                 theaudiodb_id: row.get(13)?,
+                photo_path: row.get::<_, Option<String>>(14)?.map(PathBuf::from),
             })
         },
     )
@@ -470,7 +472,8 @@ pub fn get_album_featuring_artists(
 ) -> Result<Vec<Artist>> {
     let mut stmt = conn.prepare(
         "SELECT DISTINCT a.id, a.name, a.name_sort, a.bio, a.country, a.genre, a.style, a.mood,
-                a.formed_year, a.born_year, a.died_year, a.disbanded, a.musicbrainz_id, a.theaudiodb_id
+                a.formed_year, a.born_year, a.died_year, a.disbanded, a.musicbrainz_id,
+                a.theaudiodb_id, a.photo_path
          FROM track_artists ta
          JOIN tracks t ON t.id = ta.track_id
          JOIN artists a ON a.id = ta.artist_id
@@ -495,6 +498,7 @@ pub fn get_album_featuring_artists(
             disbanded: row.get(11)?,
             musicbrainz_id: row.get(12)?,
             theaudiodb_id: row.get(13)?,
+            photo_path: row.get::<_, Option<String>>(14)?.map(PathBuf::from),
         })
     })?;
 
@@ -671,7 +675,8 @@ pub fn get_artist_albums(conn: &Connection, artist_id: i64) -> Result<Vec<Album>
 pub fn list_artists(conn: &Connection) -> Result<Vec<Artist>> {
     let mut stmt = conn.prepare(
         "SELECT id, name, name_sort, bio, country, genre, style, mood,
-                formed_year, born_year, died_year, disbanded, musicbrainz_id, theaudiodb_id
+                formed_year, born_year, died_year, disbanded, musicbrainz_id, theaudiodb_id,
+                photo_path
          FROM artists ORDER BY COALESCE(name_sort, name)",
     )?;
 
@@ -691,6 +696,7 @@ pub fn list_artists(conn: &Connection) -> Result<Vec<Artist>> {
             disbanded: row.get(11)?,
             musicbrainz_id: row.get(12)?,
             theaudiodb_id: row.get(13)?,
+            photo_path: row.get::<_, Option<String>>(14)?.map(PathBuf::from),
         })
     })?;
 
@@ -735,12 +741,41 @@ pub fn get_genre_albums(conn: &Connection, genre_id: i64) -> Result<Vec<Album>> 
     albums.collect()
 }
 
+/// Return up to `limit` local artwork file paths for albums in `genre_id`.
+/// Only returns paths that exist on disk. Used to build mosaic thumbnails.
+pub fn get_genre_artwork_paths(
+    conn: &Connection,
+    genre_id: i64,
+    limit: usize,
+) -> Result<Vec<PathBuf>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT COALESCE(a.online_artwork_path, a.artwork_path)
+         FROM albums a
+         JOIN tracks t ON t.album_id = a.id
+         JOIN track_genres tg ON tg.track_id = t.id
+         WHERE tg.genre_id = ?1
+           AND (a.online_artwork_path IS NOT NULL OR a.artwork_path IS NOT NULL)
+         ORDER BY a.year DESC
+         LIMIT ?2",
+    )?;
+    let paths: Vec<PathBuf> = stmt
+        .query_map(params![genre_id, limit as i64], |row| {
+            row.get::<_, String>(0)
+        })?
+        .filter_map(|r| r.ok())
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+        .collect();
+    Ok(paths)
+}
+
 /// Return artists for whom at least 25 % of their tracks are tagged with `genre_id`.
 /// At most 20 results, ordered alphabetically.
 pub fn get_genre_artists(conn: &Connection, genre_id: i64) -> Result<Vec<Artist>> {
     let mut stmt = conn.prepare(
         "SELECT a.id, a.name, a.name_sort, a.bio, a.country, a.genre, a.style, a.mood,
-                a.formed_year, a.born_year, a.died_year, a.disbanded, a.musicbrainz_id, a.theaudiodb_id
+                a.formed_year, a.born_year, a.died_year, a.disbanded, a.musicbrainz_id,
+                a.theaudiodb_id, a.photo_path
          FROM artists a
          WHERE a.id IN (
              SELECT t.artist_id
@@ -753,7 +788,7 @@ pub fn get_genre_artists(conn: &Connection, genre_id: i64) -> Result<Vec<Artist>
              ) >= 25
          )
          ORDER BY a.name
-         LIMIT 20"
+         LIMIT 20",
     )?;
 
     let artists = stmt.query_map(params![genre_id], |row| {
@@ -772,6 +807,7 @@ pub fn get_genre_artists(conn: &Connection, genre_id: i64) -> Result<Vec<Artist>
             disbanded: row.get(11)?,
             musicbrainz_id: row.get(12)?,
             theaudiodb_id: row.get(13)?,
+            photo_path: row.get::<_, Option<String>>(14)?.map(PathBuf::from),
         })
     })?;
 
@@ -791,7 +827,8 @@ pub fn get_similar_artists(conn: &Connection, artist_id: i64) -> Result<Vec<Arti
     //    tracks share the same genre as ≥25% of the reference artist's tracks.
     let mut stmt = conn.prepare(
         "SELECT id, name, name_sort, bio, country, genre, style, mood,
-                formed_year, born_year, died_year, disbanded, musicbrainz_id, theaudiodb_id
+                formed_year, born_year, died_year, disbanded, musicbrainz_id, theaudiodb_id,
+                photo_path
          FROM artists
          WHERE id != ?1
            AND (
@@ -845,6 +882,7 @@ pub fn get_similar_artists(conn: &Connection, artist_id: i64) -> Result<Vec<Arti
             disbanded: row.get(11)?,
             musicbrainz_id: row.get(12)?,
             theaudiodb_id: row.get(13)?,
+            photo_path: row.get::<_, Option<String>>(14)?.map(PathBuf::from),
         })
     })?;
 
@@ -1130,7 +1168,8 @@ pub fn search_library(
     let mut artists = Vec::new();
     let mut stmt = conn.prepare(
         "SELECT id, name, name_sort, bio, country, genre, style, mood,
-                formed_year, born_year, died_year, disbanded, musicbrainz_id, theaudiodb_id
+                formed_year, born_year, died_year, disbanded, musicbrainz_id, theaudiodb_id,
+                photo_path
          FROM artists
          WHERE name LIKE ?1
          LIMIT ?2",
@@ -1152,6 +1191,7 @@ pub fn search_library(
             disbanded: row.get(11)?,
             musicbrainz_id: row.get(12)?,
             theaudiodb_id: row.get(13)?,
+            photo_path: row.get::<_, Option<String>>(14)?.map(PathBuf::from),
         })
     })?;
 
@@ -1412,7 +1452,11 @@ mod tests {
         link_track_artist(&conn, track_id, sia, 1).unwrap();
 
         let sia_albums = get_artist_albums(&conn, sia).unwrap();
-        assert_eq!(sia_albums.len(), 1, "Sia must see the album via track_artists");
+        assert_eq!(
+            sia_albums.len(),
+            1,
+            "Sia must see the album via track_artists"
+        );
         assert_eq!(sia_albums[0].title, "Titanium");
 
         let guetta_albums = get_artist_albums(&conn, guetta).unwrap();
@@ -1967,7 +2011,10 @@ mod tests {
         let artists = get_genre_artists(&conn, genre_id).unwrap();
         let ids: Vec<i64> = artists.iter().map(|a| a.id).collect();
         assert!(ids.contains(&artist_a_id), "Artist A (100%) should appear");
-        assert!(!ids.contains(&artist_b_id), "Artist B (20%) should be filtered out");
+        assert!(
+            !ids.contains(&artist_b_id),
+            "Artist B (20%) should be filtered out"
+        );
     }
 
     #[test]
@@ -2616,14 +2663,15 @@ mod tests {
         link_track_artist(&conn, track_id, feat, 1).unwrap();
 
         let stats = clean_orphans(&conn).unwrap();
-        assert_eq!(stats.artists_deleted, 0, "featured artist must not be deleted");
+        assert_eq!(
+            stats.artists_deleted, 0,
+            "featured artist must not be deleted"
+        );
 
         let feat_still_exists: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM artists WHERE id = ?1",
-                [feat],
-                |r| r.get(0),
-            )
+            .query_row("SELECT COUNT(*) FROM artists WHERE id = ?1", [feat], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(feat_still_exists, 1);
     }
@@ -2639,10 +2687,20 @@ mod tests {
         let album = insert_album(&conn, "Collab", stromae, None).unwrap();
 
         let track_id = insert_track(
-            &conn, "T", Some(album), stromae, source,
-            &PathBuf::from("/t.flac"), 60_000, None, None, None,
-            AudioFormat::Flac, 1_000_000,
-        ).unwrap();
+            &conn,
+            "T",
+            Some(album),
+            stromae,
+            source,
+            &PathBuf::from("/t.flac"),
+            60_000,
+            None,
+            None,
+            None,
+            AudioFormat::Flac,
+            1_000_000,
+        )
+        .unwrap();
 
         link_track_artist(&conn, track_id, stromae, 0).unwrap();
         link_track_artist(&conn, track_id, orelsan, 1).unwrap();
@@ -2651,7 +2709,10 @@ mod tests {
         let featuring = get_album_featuring_artists(&conn, album, stromae).unwrap();
         let names: Vec<&str> = featuring.iter().map(|a| a.name.as_str()).collect();
         assert!(names.contains(&"OrelSan"), "OrelSan must be in featuring");
-        assert!(names.contains(&"Maitre Gims"), "Maitre Gims must be in featuring");
+        assert!(
+            names.contains(&"Maitre Gims"),
+            "Maitre Gims must be in featuring"
+        );
         assert!(!names.contains(&"Stromae"), "album artist must be excluded");
     }
 
@@ -2663,13 +2724,26 @@ mod tests {
         let adele = insert_artist(&conn, "Adele", None).unwrap();
         let album = insert_album(&conn, "21", adele, None).unwrap();
         let track_id = insert_track(
-            &conn, "T", Some(album), adele, source,
-            &PathBuf::from("/t.flac"), 60_000, None, None, None,
-            AudioFormat::Flac, 1_000_000,
-        ).unwrap();
+            &conn,
+            "T",
+            Some(album),
+            adele,
+            source,
+            &PathBuf::from("/t.flac"),
+            60_000,
+            None,
+            None,
+            None,
+            AudioFormat::Flac,
+            1_000_000,
+        )
+        .unwrap();
         link_track_artist(&conn, track_id, adele, 0).unwrap();
 
         let featuring = get_album_featuring_artists(&conn, album, adele).unwrap();
-        assert!(featuring.is_empty(), "solo album must have no featuring artists");
+        assert!(
+            featuring.is_empty(),
+            "solo album must have no featuring artists"
+        );
     }
 }

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -332,7 +332,6 @@ pub fn insert_track(
         params![source_id, file_path_str],
         |row| row.get(0),
     )
-    .map_err(Into::into)
 }
 
 /// Fetch a track by primary key, including a denormalised list of artist names.

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -292,6 +292,8 @@ pub fn insert_track(
     file_type: AudioFormat,
     file_size: u64,
 ) -> Result<i64> {
+    let file_path_str = file_path.to_string_lossy().into_owned();
+
     conn.execute(
         "INSERT INTO tracks (
             title, album_id, artist_id, source_id, file_path,
@@ -309,7 +311,7 @@ pub fn insert_track(
             album_id,
             artist_id,
             source_id,
-            file_path.to_string_lossy().into_owned(),
+            file_path_str,
             duration_ms,
             track_number,
             sample_rate,
@@ -319,7 +321,17 @@ pub fn insert_track(
         ],
     )?;
 
-    Ok(conn.last_insert_rowid())
+    let rowid = conn.last_insert_rowid();
+    if rowid != 0 {
+        return Ok(rowid);
+    }
+    // ON CONFLICT DO UPDATE hit — last_insert_rowid() may return 0.
+    // Fall back to querying the existing row by (source_id, file_path).
+    conn.query_row(
+        "SELECT id FROM tracks WHERE source_id = ?1 AND file_path = ?2",
+        params![source_id, file_path_str],
+        |row| row.get(0),
+    ).map_err(Into::into)
 }
 
 /// Fetch a track by primary key, including a denormalised list of artist names.
@@ -1234,11 +1246,18 @@ pub fn get_playlist(conn: &Connection, id: i64) -> Result<Option<Playlist>> {
         .optional()?;
 
     if let Some((id, name, description, created_at, updated_at)) = playlist {
-        // Get track IDs in order
+        // Get track entries (id + timestamp) in position order
         let mut stmt = conn.prepare(
-            "SELECT track_id FROM playlist_tracks WHERE playlist_id = ?1 ORDER BY position",
+            "SELECT track_id, added_at FROM playlist_tracks WHERE playlist_id = ?1 ORDER BY position",
         )?;
-        let tracks: Result<Vec<i64>> = stmt.query_map(params![id], |row| row.get(0))?.collect();
+        let tracks: Result<Vec<crate::models::PlaylistTrack>> = stmt
+            .query_map(params![id], |row| {
+                Ok(crate::models::PlaylistTrack {
+                    track_id: row.get(0)?,
+                    added_at: row.get(1)?,
+                })
+            })?
+            .collect();
 
         Ok(Some(Playlist {
             id,
@@ -1751,7 +1770,8 @@ mod tests {
         add_track_to_playlist(&conn, pl_id, t1).unwrap();
         add_track_to_playlist(&conn, pl_id, t2).unwrap();
         let pl = get_playlist(&conn, pl_id).unwrap().unwrap();
-        assert_eq!(pl.tracks, vec![t1, t2]);
+        let ids: Vec<i64> = pl.tracks.iter().map(|pt| pt.track_id).collect();
+        assert_eq!(ids, vec![t1, t2]);
     }
 
     #[test]
@@ -1771,7 +1791,7 @@ mod tests {
         .unwrap();
         let pl = get_playlist(&conn, pl_id).unwrap().unwrap();
         assert_eq!(pl.tracks.len(), 1);
-        assert_eq!(pl.tracks[0], t2);
+        assert_eq!(pl.tracks[0].track_id, t2);
     }
 
     #[test]
@@ -1795,8 +1815,8 @@ mod tests {
         add_track_to_playlist(&conn, pl_id, t2).unwrap();
         let pl = get_playlist(&conn, pl_id).unwrap().unwrap();
         // Should be in insertion order (positions 0, 1)
-        assert_eq!(pl.tracks[0], t1);
-        assert_eq!(pl.tracks[1], t2);
+        assert_eq!(pl.tracks[0].track_id, t1);
+        assert_eq!(pl.tracks[1].track_id, t2);
     }
 
     #[test]

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -331,7 +331,8 @@ pub fn insert_track(
         "SELECT id FROM tracks WHERE source_id = ?1 AND file_path = ?2",
         params![source_id, file_path_str],
         |row| row.get(0),
-    ).map_err(Into::into)
+    )
+    .map_err(Into::into)
 }
 
 /// Fetch a track by primary key, including a denormalised list of artist names.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2417,22 +2417,50 @@ fn import_files(paths_json: &str) -> String {
     // Find or create "Imported" playlist and add the newly imported tracks.
     // Failures here are non-fatal: the import itself succeeded.
     let playlist_id: Option<i64> = if !track_ids.is_empty() {
-        get_or_init_pool().ok().and_then(|pool| {
-            let playlist_service = playlist::PlaylistService::new(pool);
-            let existing = playlist_service.list_playlists().unwrap_or_default();
-            let playlist_id = existing
-                .iter()
-                .find(|p| p.name == "Imported")
-                .map(|p| p.id)
-                .or_else(|| {
-                    playlist_service
-                        .create_playlist("Imported", None)
-                        .ok()
-                        .map(|p| p.id)
-                })?;
-            playlist_service.add_tracks(playlist_id, track_ids).ok()?;
-            Some(playlist_id)
-        })
+        match get_or_init_pool() {
+            Err(e) => {
+                log::warn!("import_files: pool error, skipping playlist: {e}");
+                None
+            }
+            Ok(pool) => {
+                let playlist_service = playlist::PlaylistService::new(pool);
+                let existing = playlist_service.list_playlists().unwrap_or_default();
+                let pid = existing
+                    .iter()
+                    .find(|p| p.name == "Imported")
+                    .map(|p| p.id)
+                    .or_else(|| {
+                        match playlist_service.create_playlist("Imported", None) {
+                            Ok(p) => Some(p.id),
+                            Err(e) => {
+                                log::warn!("import_files: create_playlist failed: {e}");
+                                None
+                            }
+                        }
+                    });
+                match pid {
+                    None => None,
+                    Some(pid) => {
+                        // Skip tracks already in the playlist to avoid duplicates.
+                        let already_in: std::collections::HashSet<i64> = existing
+                            .iter()
+                            .find(|p| p.id == pid)
+                            .map(|p| p.tracks.iter().map(|pt| pt.track_id).collect())
+                            .unwrap_or_default();
+                        let new_tracks: Vec<i64> = track_ids
+                            .into_iter()
+                            .filter(|id| !already_in.contains(id))
+                            .collect();
+                        if !new_tracks.is_empty() {
+                            if let Err(e) = playlist_service.add_tracks(pid, new_tracks) {
+                                log::warn!("import_files: add_tracks failed: {e}");
+                            }
+                        }
+                        Some(pid)
+                    }
+                }
+            }
+        }
     } else {
         None
     };
@@ -2777,6 +2805,26 @@ mod tests {
         let playlist_service = PlaylistService::new(env.pool.clone());
         let playlist = playlist_service.get_playlist(id1).unwrap().unwrap();
         assert_eq!(playlist.tracks.len(), 2, "both tracks must be in the playlist");
+    }
+
+    #[test]
+    fn test_import_files_reimport_same_file_still_creates_playlist() {
+        // Importing the same file twice triggers an upsert (ON CONFLICT DO UPDATE).
+        // The second call must still return a valid playlist_id.
+        let env = TestEnv::new();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let flac = tmp.path().join("song.flac");
+        std::fs::write(&flac, MINIMAL_FLAC).unwrap();
+
+        let (count1, p1) = import_with_env(&env, &[flac.clone()]);
+        assert_eq!(count1, 1, "first import: 1 track");
+        let (pid1, _) = p1.expect("first import: playlist created");
+
+        // Import same file again
+        let (count2, p2) = import_with_env(&env, &[flac]);
+        assert_eq!(count2, 1, "second import: 1 track (upserted)");
+        let (pid2, _) = p2.expect("second import: playlist still returned despite upsert");
+        assert_eq!(pid1, pid2, "same playlist reused");
     }
 
     // ── get_tracks_page — sorting ────────────────────────────────────────────

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2348,7 +2348,11 @@ fn get_album_featuring_artists(album_id: i64, exclude_artist_id: i64) -> String 
                 }
             };
 
-            match crate::db::queries::get_album_featuring_artists(&conn, album_id, exclude_artist_id) {
+            match crate::db::queries::get_album_featuring_artists(
+                &conn,
+                album_id,
+                exclude_artist_id,
+            ) {
                 Ok(artists) => serde_json::json!({
                     "success": true,
                     "data": { "artists": artists }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2451,10 +2451,10 @@ fn import_files(paths_json: &str) -> String {
                             .into_iter()
                             .filter(|id| !already_in.contains(id))
                             .collect();
-                        if !new_tracks.is_empty() {
-                            if let Err(e) = playlist_service.add_tracks(pid, new_tracks) {
-                                log::warn!("import_files: add_tracks failed: {e}");
-                            }
+                        if !new_tracks.is_empty()
+                            && let Err(e) = playlist_service.add_tracks(pid, new_tracks)
+                        {
+                            log::warn!("import_files: add_tracks failed: {e}");
                         }
                         Some(pid)
                     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2429,15 +2429,15 @@ fn import_files(paths_json: &str) -> String {
                     .iter()
                     .find(|p| p.name == "Imported")
                     .map(|p| p.id)
-                    .or_else(|| {
-                        match playlist_service.create_playlist("Imported", None) {
+                    .or_else(
+                        || match playlist_service.create_playlist("Imported", None) {
                             Ok(p) => Some(p.id),
                             Err(e) => {
                                 log::warn!("import_files: create_playlist failed: {e}");
                                 None
                             }
-                        }
-                    });
+                        },
+                    );
                 match pid {
                     None => None,
                     Some(pid) => {
@@ -2804,7 +2804,11 @@ mod tests {
         // Verify both tracks are now in the single "Imported" playlist.
         let playlist_service = PlaylistService::new(env.pool.clone());
         let playlist = playlist_service.get_playlist(id1).unwrap().unwrap();
-        assert_eq!(playlist.tracks.len(), 2, "both tracks must be in the playlist");
+        assert_eq!(
+            playlist.tracks.len(),
+            2,
+            "both tracks must be in the playlist"
+        );
     }
 
     #[test]
@@ -3148,5 +3152,4 @@ mod tests {
             );
         }
     }
-
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2390,27 +2390,65 @@ fn import_files(paths_json: &str) -> String {
 
     let path_bufs: Vec<PathBuf> = path_strings.iter().map(PathBuf::from).collect();
 
-    match get_or_init_library() {
-        Ok(library_service) => match library_service.import_paths(&path_bufs) {
-            Ok(track_ids) => serde_json::json!({
-                "success": true,
-                "data": {
-                    "tracks_imported": track_ids.len()
-                }
+    let library_service = match get_or_init_library() {
+        Ok(s) => s,
+        Err(e) => {
+            return serde_json::json!({
+                "success": false,
+                "error": format!("FFI initialization failed: {}", e)
             })
-            .to_string(),
-            Err(e) => serde_json::json!({
+            .to_string();
+        }
+    };
+
+    let track_ids = match library_service.import_paths(&path_bufs) {
+        Ok(ids) => ids,
+        Err(e) => {
+            return serde_json::json!({
                 "success": false,
                 "error": format!("Failed to import paths: {}", e)
             })
-            .to_string(),
-        },
-        Err(e) => serde_json::json!({
-            "success": false,
-            "error": format!("FFI initialization failed: {}", e)
+            .to_string();
+        }
+    };
+
+    let tracks_imported = track_ids.len();
+
+    // Find or create "Imported" playlist and add the newly imported tracks.
+    // Failures here are non-fatal: the import itself succeeded.
+    let playlist_id: Option<i64> = if !track_ids.is_empty() {
+        get_or_init_pool().ok().and_then(|pool| {
+            let playlist_service = playlist::PlaylistService::new(pool);
+            let existing = playlist_service.list_playlists().unwrap_or_default();
+            let playlist_id = existing
+                .iter()
+                .find(|p| p.name == "Imported")
+                .map(|p| p.id)
+                .or_else(|| {
+                    playlist_service
+                        .create_playlist("Imported", None)
+                        .ok()
+                        .map(|p| p.id)
+                })?;
+            playlist_service.add_tracks(playlist_id, track_ids).ok()?;
+            Some(playlist_id)
         })
-        .to_string(),
+    } else {
+        None
+    };
+
+    let mut data = serde_json::json!({
+        "tracks_imported": tracks_imported
+    });
+    if let Some(id) = playlist_id {
+        data["playlist_id"] = serde_json::json!(id);
     }
+
+    serde_json::json!({
+        "success": true,
+        "data": data
+    })
+    .to_string()
 }
 
 // Artwork Fetching Functions
@@ -2630,74 +2668,6 @@ mod tests {
 
     const MINIMAL_FLAC: &[u8] = include_bytes!("../tests/fixtures/minimal.flac");
 
-    /// Given a base name and a set of names already in use, return the first
-    /// available name: `base`, then `base-2`, `base-3`, etc.
-    fn unique_playlist_name(base: &str, existing: &std::collections::HashSet<String>) -> String {
-        if !existing.contains(base) {
-            return base.to_string();
-        }
-        let mut suffix = 2usize;
-        loop {
-            let candidate = format!("{}-{}", base, suffix);
-            if !existing.contains(&candidate) {
-                return candidate;
-            }
-            suffix += 1;
-        }
-    }
-
-    // ── unique_playlist_name ─────────────────────────────────────────────────
-
-    #[test]
-    fn test_unique_name_no_collision() {
-        let existing: std::collections::HashSet<String> = std::collections::HashSet::new();
-        assert_eq!(
-            unique_playlist_name("import-2026-02-17", &existing),
-            "import-2026-02-17"
-        );
-    }
-
-    #[test]
-    fn test_unique_name_first_collision() {
-        let existing: std::collections::HashSet<String> =
-            ["import-2026-02-17".to_string()].into_iter().collect();
-        assert_eq!(
-            unique_playlist_name("import-2026-02-17", &existing),
-            "import-2026-02-17-2"
-        );
-    }
-
-    #[test]
-    fn test_unique_name_multiple_collisions() {
-        let existing: std::collections::HashSet<String> = [
-            "import-2026-02-17".to_string(),
-            "import-2026-02-17-2".to_string(),
-            "import-2026-02-17-3".to_string(),
-        ]
-        .into_iter()
-        .collect();
-        assert_eq!(
-            unique_playlist_name("import-2026-02-17", &existing),
-            "import-2026-02-17-4"
-        );
-    }
-
-    #[test]
-    fn test_unique_name_gap_in_suffixes() {
-        // -2 exists but -3 does not: should return -2 wait, no — it tries 2 first
-        let existing: std::collections::HashSet<String> = [
-            "import-2026-02-17".to_string(),
-            "import-2026-02-17-3".to_string(),
-        ]
-        .into_iter()
-        .collect();
-        // -2 is free, so we get -2 (gap is irrelevant)
-        assert_eq!(
-            unique_playlist_name("import-2026-02-17", &existing),
-            "import-2026-02-17-2"
-        );
-    }
-
     // ── import_files JSON parsing ────────────────────────────────────────────
 
     #[test]
@@ -2728,6 +2698,7 @@ mod tests {
     }
 
     /// Helper: run the import business logic against a TestEnv's pool (bypasses global singleton).
+    /// Mirrors the find-or-create "Imported" playlist logic in `import_files`.
     fn import_with_env(
         env: &TestEnv,
         file_paths: &[std::path::PathBuf],
@@ -2743,27 +2714,33 @@ mod tests {
         }
         let tracks_imported = track_ids.len();
 
-        let base_name = chrono::Local::now().format("import-%Y-%m-%d").to_string();
-        let existing_names: std::collections::HashSet<String> = playlist_service
-            .list_playlists()
-            .unwrap_or_default()
+        // Find existing "Imported" playlist or create one.
+        let existing = playlist_service.list_playlists().unwrap_or_default();
+        let playlist_id = existing
             .iter()
-            .map(|p| p.name.clone())
-            .collect();
-        let playlist_name = unique_playlist_name(&base_name, &existing_names);
+            .find(|p| p.name == "Imported")
+            .map(|p| p.id)
+            .unwrap_or_else(|| {
+                playlist_service
+                    .create_playlist("Imported", None)
+                    .expect("create_playlist failed")
+                    .id
+            });
+
+        playlist_service
+            .add_tracks(playlist_id, track_ids)
+            .expect("add_tracks failed");
 
         let playlist = playlist_service
-            .create_playlist(&playlist_name, None)
-            .expect("create_playlist failed");
-        playlist_service
-            .add_tracks(playlist.id, track_ids)
-            .expect("add_tracks failed");
+            .get_playlist(playlist_id)
+            .expect("get_playlist failed")
+            .expect("playlist must exist");
 
         (tracks_imported, Some((playlist.id, playlist.name)))
     }
 
     #[test]
-    fn test_import_files_valid_flac_creates_playlist() {
+    fn test_import_files_valid_flac_creates_imported_playlist() {
         let env = TestEnv::new();
         let tmp = tempfile::TempDir::new().unwrap();
         let flac = tmp.path().join("song.flac");
@@ -2774,11 +2751,32 @@ mod tests {
         assert_eq!(count, 1, "should import exactly 1 track");
         let (id, name) = playlist.expect("playlist should be created");
         assert!(id > 0, "playlist id must be positive");
-        assert!(
-            name.starts_with("import-"),
-            "playlist name must start with 'import-', got: {}",
-            name
-        );
+        assert_eq!(name, "Imported", "playlist must be named 'Imported'");
+    }
+
+    #[test]
+    fn test_import_files_second_import_reuses_imported_playlist() {
+        let env = TestEnv::new();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let flac1 = tmp.path().join("a.flac");
+        let flac2 = tmp.path().join("b.flac");
+        std::fs::write(&flac1, MINIMAL_FLAC).unwrap();
+        std::fs::write(&flac2, MINIMAL_FLAC).unwrap();
+
+        let (_, p1) = import_with_env(&env, &[flac1]);
+        let (_, p2) = import_with_env(&env, &[flac2]);
+
+        let (id1, name1) = p1.expect("first import should create a playlist");
+        let (id2, name2) = p2.expect("second import should reuse the playlist");
+
+        assert_eq!(id1, id2, "both imports must reuse the same playlist");
+        assert_eq!(name1, "Imported");
+        assert_eq!(name2, "Imported");
+
+        // Verify both tracks are now in the single "Imported" playlist.
+        let playlist_service = PlaylistService::new(env.pool.clone());
+        let playlist = playlist_service.get_playlist(id1).unwrap().unwrap();
+        assert_eq!(playlist.tracks.len(), 2, "both tracks must be in the playlist");
     }
 
     // ── get_tracks_page — sorting ────────────────────────────────────────────
@@ -3103,29 +3101,4 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_import_files_second_import_same_day_gets_suffix() {
-        let env = TestEnv::new();
-        let tmp = tempfile::TempDir::new().unwrap();
-        let flac1 = tmp.path().join("a.flac");
-        let flac2 = tmp.path().join("b.flac");
-        std::fs::write(&flac1, MINIMAL_FLAC).unwrap();
-        std::fs::write(&flac2, MINIMAL_FLAC).unwrap();
-
-        let (_, p1) = import_with_env(&env, &[flac1]);
-        let (_, p2) = import_with_env(&env, &[flac2]);
-
-        let name1 = p1.expect("first import should create a playlist").1;
-        let name2 = p2.expect("second import should create a playlist").1;
-
-        assert_ne!(
-            name1, name2,
-            "two imports on the same day must get distinct names"
-        );
-        assert!(
-            name2.ends_with("-2"),
-            "second import should get '-2' suffix, got: {}",
-            name2
-        );
-    }
 }

--- a/src/models/artist.rs
+++ b/src/models/artist.rs
@@ -1,6 +1,7 @@
 //! Artist domain model.
 
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 /// A recording artist or band as stored in the library database.
 ///
@@ -37,4 +38,6 @@ pub struct Artist {
     pub musicbrainz_id: Option<String>,
     /// TheAudioDB numeric artist ID (stored as a string to match the API response).
     pub theaudiodb_id: Option<String>,
+    /// Local path to the cached artist photo (downloaded from TheAudioDB).
+    pub photo_path: Option<PathBuf>,
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -22,7 +22,7 @@ pub mod track;
 pub use album::Album;
 pub use artist::Artist;
 pub use genre::Genre;
-pub use playlist::{Playlist, Queue, RepeatMode};
+pub use playlist::{Playlist, PlaylistTrack, Queue, RepeatMode};
 pub use source::Source;
 pub use track::{AudioFormat, InvalidRating, Rating, Track, TrackBuilder};
 

--- a/src/models/playlist.rs
+++ b/src/models/playlist.rs
@@ -2,6 +2,15 @@
 
 use serde::{Deserialize, Serialize};
 
+/// A track entry within a playlist, carrying its position timestamp.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlaylistTrack {
+    /// Foreign key into the `tracks` table.
+    pub track_id: i64,
+    /// When this track was added to the playlist (ISO 8601, UTC).
+    pub added_at: String,
+}
+
 /// A named, ordered collection of tracks saved by the user.
 ///
 /// Playlists are persisted in the `playlists` / `playlist_tracks` tables and
@@ -14,8 +23,8 @@ pub struct Playlist {
     pub name: String,
     /// Optional free-text description.
     pub description: Option<String>,
-    /// Ordered list of track IDs that make up this playlist.
-    pub tracks: Vec<i64>,
+    /// Ordered list of playlist-track entries (track ID + added_at timestamp).
+    pub tracks: Vec<PlaylistTrack>,
     /// Creation timestamp (ISO 8601, UTC).
     pub created_at: String,
     /// Last modification timestamp (ISO 8601, UTC).

--- a/src/services/audio_engine.rs
+++ b/src/services/audio_engine.rs
@@ -13,7 +13,9 @@
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{BufferSize, SampleRate, StreamConfig, SupportedBufferSize};
-use log::{info, warn};
+use log::warn;
+#[cfg(target_os = "macos")]
+use log::info;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering::Relaxed, Ordering::Release};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
@@ -318,6 +320,7 @@ impl AudioEngine {
 
         // On macOS, set the HAL-level buffer size BEFORE opening the stream.
         // Use the DEVICE sample rate for HAL (it controls the hardware clock).
+        #[cfg(target_os = "macos")]
         let hal_target = (device_sample_rate as f64 * TARGET_BUFFER_MS / 1000.0) as u32;
         #[cfg(target_os = "macos")]
         match hal::set_default_output_buffer_size(hal_target) {

--- a/src/services/audio_engine.rs
+++ b/src/services/audio_engine.rs
@@ -13,9 +13,9 @@
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{BufferSize, SampleRate, StreamConfig, SupportedBufferSize};
-use log::warn;
 #[cfg(target_os = "macos")]
 use log::info;
+use log::warn;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering::Relaxed, Ordering::Release};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};

--- a/src/services/audio_engine.rs
+++ b/src/services/audio_engine.rs
@@ -146,9 +146,7 @@ mod hal {
                 &mut actual as *mut _ as *mut c_void,
             );
             if status != 0 {
-                return Err(format!(
-                    "read back buffer size failed: OSStatus {status}"
-                ));
+                return Err(format!("read back buffer size failed: OSStatus {status}"));
             }
 
             Ok(actual)
@@ -164,8 +162,8 @@ pub struct SharedState {
     pub paused: AtomicBool,
     pub stopped: AtomicBool,
     pub finished: AtomicBool,
-    pub volume: AtomicU32,            // f32 bits stored as u32
-    pub callback_frames: AtomicU32,   // actual frames per callback (set once)
+    pub volume: AtomicU32,          // f32 bits stored as u32
+    pub callback_frames: AtomicU32, // actual frames per callback (set once)
 }
 
 impl SharedState {
@@ -325,7 +323,9 @@ impl AudioEngine {
         match hal::set_default_output_buffer_size(hal_target) {
             Ok(actual) => {
                 let ms = actual as f64 / device_sample_rate as f64 * 1000.0;
-                write_diag(&format!("HAL buffer size: requested={hal_target}, actual={actual} ({ms:.1} ms)"));
+                write_diag(&format!(
+                    "HAL buffer size: requested={hal_target}, actual={actual} ({ms:.1} ms)"
+                ));
                 info!("AudioEngine: HAL buffer size set to {actual} frames ({ms:.1} ms)");
             }
             Err(e) => {
@@ -338,11 +338,15 @@ impl AudioEngine {
         let cpal_buffer_size = match supported.buffer_size() {
             SupportedBufferSize::Range { min, max } => {
                 let clamped = target_frames.clamp(*min, *max);
-                write_diag(&format!("cpal buffer: {clamped} frames (range {min}–{max})"));
+                write_diag(&format!(
+                    "cpal buffer: {clamped} frames (range {min}–{max})"
+                ));
                 BufferSize::Fixed(clamped)
             }
             SupportedBufferSize::Unknown => {
-                write_diag(&format!("cpal buffer: range unknown, requesting {target_frames}"));
+                write_diag(&format!(
+                    "cpal buffer: range unknown, requesting {target_frames}"
+                ));
                 BufferSize::Fixed(target_frames)
             }
         };

--- a/src/services/events.rs
+++ b/src/services/events.rs
@@ -52,7 +52,7 @@ pub enum PlaybackState {
 #[derive(Debug, Clone)]
 pub enum PlayerEvent {
     StateChanged { state: PlaybackState },
-    TrackChanged { track: Option<Track> },
+    TrackChanged { track: Option<Box<Track>> },
     PositionChanged { position: Duration },
     QueueChanged { queue: Vec<i64> },
     VolumeChanged { volume: f32 },

--- a/src/services/library.rs
+++ b/src/services/library.rs
@@ -48,8 +48,18 @@ pub(crate) fn extract_feat_from_title(title: &str) -> Vec<String> {
 
     // Longest patterns first to avoid partial matches.
     const MARKERS: &[&str] = &[
-        "(featuring ", "(feat. ", "(feat ", "(ft. ", "(ft ", "(avec ",
-        "[featuring ", "[feat. ", "[feat ", "[ft. ", "[ft ", "[avec ",
+        "(featuring ",
+        "(feat. ",
+        "(feat ",
+        "(ft. ",
+        "(ft ",
+        "(avec ",
+        "[featuring ",
+        "[feat. ",
+        "[feat ",
+        "[ft. ",
+        "[ft ",
+        "[avec ",
     ];
 
     for marker in MARKERS {
@@ -99,7 +109,7 @@ pub(crate) fn split_artists(artist: &str) -> Vec<String> {
         || lower.contains(" feat")    // feat, feat., featuring
         || lower.contains(" ft")      // ft, ft.
         || lower.contains(" avec ")
-        || lower.contains(" vs");     // vs, vs.
+        || lower.contains(" vs"); // vs, vs.
 
     if !has_context {
         return vec![trimmed.to_string()];
@@ -476,7 +486,10 @@ impl LibraryService {
         // Also link featured artists extracted from the track title
         // (e.g. "Titanium (feat. Sia)" when ARTIST tag only contains "David Guetta").
         let title_offset = artists.len() as u32;
-        for (pos, name) in extract_feat_from_title(&metadata.title).into_iter().enumerate() {
+        for (pos, name) in extract_feat_from_title(&metadata.title)
+            .into_iter()
+            .enumerate()
+        {
             let aid = queries::insert_artist(conn, &name, None)?;
             queries::link_track_artist(conn, track_id, aid, title_offset + pos as u32)?;
         }
@@ -762,11 +775,38 @@ impl LibraryService {
         queries::get_artist(&conn, id).map_err(LibraryError::Database)
     }
 
+    /// Return `count` random track IDs from the library (capped at 200).
+    pub fn get_random_tracks(&self, count: usize) -> Result<Vec<i64>> {
+        let conn = self.pool.get()?;
+        let n = count.min(200);
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT id FROM tracks ORDER BY RANDOM() LIMIT {n}"
+            ))
+            .map_err(LibraryError::Database)?;
+        let ids: Vec<i64> = stmt
+            .query_map([], |row| row.get(0))
+            .map_err(LibraryError::Database)?
+            .filter_map(|r| r.ok())
+            .collect();
+        Ok(ids)
+    }
+
     /// Return all artists in the library, ordered alphabetically by name.
     pub fn list_artists(&self) -> Result<Vec<Artist>> {
         let conn = self.pool.get()?;
 
         queries::list_artists(&conn).map_err(LibraryError::Database)
+    }
+
+    /// Return up to `limit` local artwork paths for albums in the given genre.
+    pub fn get_genre_artwork_paths(
+        &self,
+        genre_id: i64,
+        limit: usize,
+    ) -> Result<Vec<std::path::PathBuf>> {
+        let conn = self.pool.get()?;
+        queries::get_genre_artwork_paths(&conn, genre_id, limit).map_err(LibraryError::Database)
     }
 
     /// Return all artists associated with the given genre.
@@ -891,10 +931,7 @@ mod tests {
 
     #[test]
     fn test_split_artists_feat() {
-        assert_eq!(
-            split_artists("Drake feat. Future"),
-            vec!["Drake", "Future"]
-        );
+        assert_eq!(split_artists("Drake feat. Future"), vec!["Drake", "Future"]);
     }
 
     #[test]
@@ -908,7 +945,10 @@ mod tests {
     #[test]
     fn test_split_artists_preserves_simon_garfunkel() {
         // No unambiguous marker → intact
-        assert_eq!(split_artists("Simon & Garfunkel"), vec!["Simon & Garfunkel"]);
+        assert_eq!(
+            split_artists("Simon & Garfunkel"),
+            vec!["Simon & Garfunkel"]
+        );
     }
 
     #[test]

--- a/src/services/library.rs
+++ b/src/services/library.rs
@@ -68,9 +68,7 @@ pub(crate) fn extract_feat_from_title(title: &str) -> Vec<String> {
         };
         let artist_start = start + marker.len();
         let rest_lower = &lower[artist_start..];
-        let closing = rest_lower
-            .find(|c| c == ')' || c == ']')
-            .unwrap_or(rest_lower.len());
+        let closing = rest_lower.find([')', ']']).unwrap_or(rest_lower.len());
         let artist_end = artist_start + closing;
 
         // Map byte offsets back to the original title for proper casing.

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -388,7 +388,7 @@ impl PlayerService {
                     self.save_queue_state();
                     return Ok(());
                 }
-                Err(PlayerError::FileNotFound(path)) if consecutive_misses < 3 => {
+                Err(PlayerError::FileNotFound(_path)) if consecutive_misses < 3 => {
                     warn!("Track {track_id} file not found in next(), skipping");
                     let mut state = self.state.lock().unwrap();
                     // Cap the set at 500 entries to prevent unbounded growth

--- a/src/services/player.rs
+++ b/src/services/player.rs
@@ -73,16 +73,19 @@ impl PlayerService {
     fn ensure_engine(&self) -> Result<()> {
         let mut engine = self.engine.lock().unwrap();
         if engine.is_none() {
-            *engine = Some(
-                AudioEngine::new()
-                    .map_err(|e| PlayerError::Audio(format!("Failed to create audio engine: {e}")))?,
-            );
+            *engine =
+                Some(AudioEngine::new().map_err(|e| {
+                    PlayerError::Audio(format!("Failed to create audio engine: {e}"))
+                })?);
         }
         Ok(())
     }
 
     /// Lock the engine and run a closure with a reference to AudioControls.
-    fn with_controls<T>(&self, f: impl FnOnce(&crate::services::audio_engine::AudioControls) -> T) -> Result<T> {
+    fn with_controls<T>(
+        &self,
+        f: impl FnOnce(&crate::services::audio_engine::AudioControls) -> T,
+    ) -> Result<T> {
         let engine = self.engine.lock().unwrap();
         let eng = engine
             .as_ref()
@@ -186,13 +189,12 @@ impl PlayerService {
                 }
             };
 
-            let source: Box<dyn Iterator<Item = f32> + Send> = Box::new(
-                UniformSourceIterator::<_, f32>::new(
+            let source: Box<dyn Iterator<Item = f32> + Send> =
+                Box::new(UniformSourceIterator::<_, f32>::new(
                     decoder.convert_samples::<f32>(),
                     dev_ch,
                     dev_sr,
-                ),
-            );
+                ));
 
             // Send source to the audio callback
             bg_handle.set_volume(volume);
@@ -325,22 +327,20 @@ impl PlayerService {
                 }
             };
 
-            let source: Box<dyn Iterator<Item = f32> + Send> = Box::new(
-                UniformSourceIterator::<_, f32>::new(
+            let source: Box<dyn Iterator<Item = f32> + Send> =
+                Box::new(UniformSourceIterator::<_, f32>::new(
                     decoder
                         .skip_duration(clamped_position)
                         .convert_samples::<f32>(),
                     dev_ch,
                     dev_sr,
-                ),
-            );
+                ));
 
             bg_handle.set_volume(volume);
             bg_handle.play_source(source);
             bg_loading.store(false, Relaxed);
 
-            bg_state.lock().unwrap().playback_start_time =
-                Some(Instant::now() - clamped_position);
+            bg_state.lock().unwrap().playback_start_time = Some(Instant::now() - clamped_position);
         });
 
         info!("Seeked to {clamped_position:?}");

--- a/src/services/playlist.rs
+++ b/src/services/playlist.rs
@@ -58,12 +58,17 @@ impl PlaylistService {
             let created_at = row.get::<_, String>(3)?;
             let updated_at = row.get::<_, String>(4)?;
 
-            // Get tracks
+            // Get track entries (id + timestamp) in position order
             let mut track_stmt = conn.prepare(
-                "SELECT track_id FROM playlist_tracks WHERE playlist_id = ?1 ORDER BY position",
+                "SELECT track_id, added_at FROM playlist_tracks WHERE playlist_id = ?1 ORDER BY position",
             )?;
-            let tracks: rusqlite::Result<Vec<i64>> = track_stmt
-                .query_map([playlist_id], |row| row.get(0))?
+            let tracks: rusqlite::Result<Vec<crate::models::PlaylistTrack>> = track_stmt
+                .query_map([playlist_id], |row| {
+                    Ok(crate::models::PlaylistTrack {
+                        track_id: row.get(0)?,
+                        added_at: row.get(1)?,
+                    })
+                })?
                 .collect();
 
             Ok(Playlist {
@@ -156,8 +161,8 @@ impl PlaylistService {
         }
 
         let mut tracks = playlist.tracks;
-        let track_id = tracks.remove(from);
-        tracks.insert(to, track_id);
+        let pt = tracks.remove(from);
+        tracks.insert(to, pt);
 
         // Delete all and recreate
         conn.execute(
@@ -165,10 +170,10 @@ impl PlaylistService {
             rusqlite::params![playlist_id],
         )?;
 
-        for (pos, track_id) in tracks.iter().enumerate() {
+        for (pos, pt) in tracks.iter().enumerate() {
             conn.execute(
-                "INSERT INTO playlist_tracks (playlist_id, track_id, position) VALUES (?1, ?2, ?3)",
-                rusqlite::params![playlist_id, track_id, pos as i64],
+                "INSERT INTO playlist_tracks (playlist_id, track_id, position, added_at) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![playlist_id, pt.track_id, pos as i64, pt.added_at],
             )?;
         }
 
@@ -230,8 +235,8 @@ impl PlaylistService {
 
         // Get track details
         let mut tracks = Vec::new();
-        for track_id in playlist.tracks {
-            if let Ok(Some(track)) = queries::get_track(&conn, track_id) {
+        for pt in playlist.tracks {
+            if let Ok(Some(track)) = queries::get_track(&conn, pt.track_id) {
                 tracks.push(track);
             }
         }
@@ -298,7 +303,8 @@ mod tests {
         let pl = service.create_playlist("Queue", None).unwrap();
         service.add_tracks(pl.id, vec![t1, t2]).unwrap();
         let updated = service.get_playlist(pl.id).unwrap().unwrap();
-        assert_eq!(updated.tracks, vec![t1, t2]);
+        let ids: Vec<i64> = updated.tracks.iter().map(|pt| pt.track_id).collect();
+        assert_eq!(ids, vec![t1, t2]);
     }
 
     #[test]
@@ -338,8 +344,8 @@ mod tests {
         service.add_tracks(pl.id, vec![t1, t2]).unwrap();
         service.move_track(pl.id, 0, 1).unwrap();
         let updated = service.get_playlist(pl.id).unwrap().unwrap();
-        assert_eq!(updated.tracks[0], t2);
-        assert_eq!(updated.tracks[1], t1);
+        assert_eq!(updated.tracks[0].track_id, t2);
+        assert_eq!(updated.tracks[1].track_id, t1);
     }
 
     // ── import_m3u ───────────────────────────────────────────────────────────

--- a/src/services/search.rs
+++ b/src/services/search.rs
@@ -184,76 +184,72 @@ impl SearchService {
         let mut track_ids: Vec<i64> = Vec::new();
 
         // 1. FTS5 prefix
-        if !fts_query.is_empty() {
-            if let Ok(mut stmt) = conn.prepare(
+        if !fts_query.is_empty()
+            && let Ok(mut stmt) = conn.prepare(
                 "SELECT t.id FROM tracks t
                  JOIN tracks_fts fts ON fts.rowid = t.id
                  WHERE tracks_fts MATCH ?1
                  ORDER BY rank LIMIT 50",
-            ) {
-                if let Ok(ids) = stmt
-                    .query_map([&fts_query], |row| row.get(0))
-                    .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
-                {
-                    for id in ids {
-                        if track_seen.insert(id) {
-                            track_ids.push(id);
-                        }
-                    }
+            )
+            && let Ok(ids) = stmt
+                .query_map([&fts_query], |row| row.get(0))
+                .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
+        {
+            for id in ids {
+                if track_seen.insert(id) {
+                    track_ids.push(id);
                 }
             }
         }
 
         // 2. LIKE substring — always, deduplicates with FTS5 results
-        if !like_q.is_empty() {
-            if let Ok(mut stmt) = conn.prepare(
+        if !like_q.is_empty()
+            && let Ok(mut stmt) = conn.prepare(
                 "SELECT t.id FROM tracks t
                  JOIN artists ar ON ar.id = t.artist_id
                  WHERE t.title LIKE '%' || ?1 || '%'
                     OR ar.name  LIKE '%' || ?1 || '%'
                  LIMIT 50",
-            ) {
-                if let Ok(ids) = stmt
-                    .query_map([&like_q], |row| row.get(0))
-                    .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
-                {
-                    for id in ids {
-                        if track_seen.insert(id) {
-                            track_ids.push(id);
-                        }
-                    }
+            )
+            && let Ok(ids) = stmt
+                .query_map([&like_q], |row| row.get(0))
+                .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
+        {
+            for id in ids {
+                if track_seen.insert(id) {
+                    track_ids.push(id);
                 }
             }
         }
 
         // 3. Levenshtein — only for queries ≥ 4 chars, adds candidates not yet found
-        if query_chars >= 4 {
-            if let Ok(mut stmt) = conn.prepare(
+        if query_chars >= 4
+            && let Ok(mut stmt) = conn.prepare(
                 "SELECT t.id, t.title, ar.name
                  FROM tracks t
                  JOIN artists ar ON ar.id = t.artist_id",
-            ) {
-                let new_ids: Vec<i64> = stmt
-                    .query_map([], |row| {
-                        Ok((
-                            row.get::<_, i64>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, String>(2)?,
-                        ))
-                    })
-                    .map_err(LibraryError::Database)?
-                    .filter_map(|r| r.ok())
-                    .filter(|(id, title, artist)| {
-                        !track_seen.contains(id)
-                            && (fuzzy_matches(&q_lower, title) || fuzzy_matches(&q_lower, artist))
-                    })
-                    .take(50)
-                    .map(|(id, _, _)| id)
-                    .collect();
-                for id in new_ids {
-                    if track_seen.insert(id) {
-                        track_ids.push(id);
-                    }
+            )
+        {
+            let new_ids: Vec<i64> = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })
+                .map_err(LibraryError::Database)?
+                .filter_map(|r| r.ok())
+                .filter(|(id, title, artist)| {
+                    !track_seen.contains(id)
+                        && (fuzzy_matches(&q_lower, title) || fuzzy_matches(&q_lower, artist))
+                })
+                .take(50)
+                .map(|(id, _, _)| id)
+                .collect();
+            for id in new_ids {
+                if track_seen.insert(id) {
+                    track_ids.push(id);
                 }
             }
         }
@@ -272,76 +268,72 @@ impl SearchService {
         let mut album_ids: Vec<i64> = Vec::new();
 
         // 1. FTS5 prefix
-        if !fts_query.is_empty() {
-            if let Ok(mut stmt) = conn.prepare(
+        if !fts_query.is_empty()
+            && let Ok(mut stmt) = conn.prepare(
                 "SELECT a.id FROM albums a
                  JOIN albums_fts fts ON fts.rowid = a.id
                  WHERE albums_fts MATCH ?1
                  ORDER BY rank LIMIT 20",
-            ) {
-                if let Ok(ids) = stmt
-                    .query_map([&fts_query], |row| row.get(0))
-                    .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
-                {
-                    for id in ids {
-                        if album_seen.insert(id) {
-                            album_ids.push(id);
-                        }
-                    }
+            )
+            && let Ok(ids) = stmt
+                .query_map([&fts_query], |row| row.get(0))
+                .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
+        {
+            for id in ids {
+                if album_seen.insert(id) {
+                    album_ids.push(id);
                 }
             }
         }
 
         // 2. LIKE substring
-        if !like_q.is_empty() {
-            if let Ok(mut stmt) = conn.prepare(
+        if !like_q.is_empty()
+            && let Ok(mut stmt) = conn.prepare(
                 "SELECT al.id FROM albums al
                  JOIN artists ar ON ar.id = al.artist_id
                  WHERE al.title LIKE '%' || ?1 || '%'
                     OR ar.name  LIKE '%' || ?1 || '%'
                  LIMIT 20",
-            ) {
-                if let Ok(ids) = stmt
-                    .query_map([&like_q], |row| row.get(0))
-                    .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
-                {
-                    for id in ids {
-                        if album_seen.insert(id) {
-                            album_ids.push(id);
-                        }
-                    }
+            )
+            && let Ok(ids) = stmt
+                .query_map([&like_q], |row| row.get(0))
+                .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
+        {
+            for id in ids {
+                if album_seen.insert(id) {
+                    album_ids.push(id);
                 }
             }
         }
 
         // 3. Levenshtein
-        if query_chars >= 4 {
-            if let Ok(mut stmt) = conn.prepare(
+        if query_chars >= 4
+            && let Ok(mut stmt) = conn.prepare(
                 "SELECT al.id, al.title, ar.name
                  FROM albums al
                  JOIN artists ar ON ar.id = al.artist_id",
-            ) {
-                let new_ids: Vec<i64> = stmt
-                    .query_map([], |row| {
-                        Ok((
-                            row.get::<_, i64>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, String>(2)?,
-                        ))
-                    })
-                    .map_err(LibraryError::Database)?
-                    .filter_map(|r| r.ok())
-                    .filter(|(id, title, artist)| {
-                        !album_seen.contains(id)
-                            && (fuzzy_matches(&q_lower, title) || fuzzy_matches(&q_lower, artist))
-                    })
-                    .take(20)
-                    .map(|(id, _, _)| id)
-                    .collect();
-                for id in new_ids {
-                    if album_seen.insert(id) {
-                        album_ids.push(id);
-                    }
+            )
+        {
+            let new_ids: Vec<i64> = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })
+                .map_err(LibraryError::Database)?
+                .filter_map(|r| r.ok())
+                .filter(|(id, title, artist)| {
+                    !album_seen.contains(id)
+                        && (fuzzy_matches(&q_lower, title) || fuzzy_matches(&q_lower, artist))
+                })
+                .take(20)
+                .map(|(id, _, _)| id)
+                .collect();
+            for id in new_ids {
+                if album_seen.insert(id) {
+                    album_ids.push(id);
                 }
             }
         }
@@ -388,61 +380,56 @@ impl SearchService {
         let mut artist_ids: Vec<i64> = Vec::new();
 
         // 1. FTS5 prefix
-        if !fts_query.is_empty() {
-            if let Ok(mut stmt) = conn.prepare(
+        if !fts_query.is_empty()
+            && let Ok(mut stmt) = conn.prepare(
                 "SELECT ar.id FROM artists ar
                  JOIN artists_fts fts ON fts.rowid = ar.id
                  WHERE artists_fts MATCH ?1
                  ORDER BY rank LIMIT 20",
-            ) {
-                if let Ok(ids) = stmt
-                    .query_map([&fts_query], |row| row.get(0))
-                    .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
-                {
-                    for id in ids {
-                        if artist_seen.insert(id) {
-                            artist_ids.push(id);
-                        }
-                    }
+            )
+            && let Ok(ids) = stmt
+                .query_map([&fts_query], |row| row.get(0))
+                .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
+        {
+            for id in ids {
+                if artist_seen.insert(id) {
+                    artist_ids.push(id);
                 }
             }
         }
 
         // 2. LIKE substring
-        if !like_q.is_empty() {
-            if let Ok(mut stmt) =
+        if !like_q.is_empty()
+            && let Ok(mut stmt) =
                 conn.prepare("SELECT id FROM artists WHERE name LIKE '%' || ?1 || '%' LIMIT 20")
-            {
-                if let Ok(ids) = stmt
-                    .query_map([&like_q], |row| row.get(0))
-                    .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
-                {
-                    for id in ids {
-                        if artist_seen.insert(id) {
-                            artist_ids.push(id);
-                        }
-                    }
+            && let Ok(ids) = stmt
+                .query_map([&like_q], |row| row.get(0))
+                .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
+        {
+            for id in ids {
+                if artist_seen.insert(id) {
+                    artist_ids.push(id);
                 }
             }
         }
 
         // 3. Levenshtein
-        if query_chars >= 4 {
-            if let Ok(mut stmt) = conn.prepare("SELECT id, name FROM artists") {
-                let new_ids: Vec<i64> = stmt
-                    .query_map([], |row| {
-                        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-                    })
-                    .map_err(LibraryError::Database)?
-                    .filter_map(|r| r.ok())
-                    .filter(|(id, name)| !artist_seen.contains(id) && fuzzy_matches(&q_lower, name))
-                    .take(20)
-                    .map(|(id, _)| id)
-                    .collect();
-                for id in new_ids {
-                    if artist_seen.insert(id) {
-                        artist_ids.push(id);
-                    }
+        if query_chars >= 4
+            && let Ok(mut stmt) = conn.prepare("SELECT id, name FROM artists")
+        {
+            let new_ids: Vec<i64> = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(LibraryError::Database)?
+                .filter_map(|r| r.ok())
+                .filter(|(id, name)| !artist_seen.contains(id) && fuzzy_matches(&q_lower, name))
+                .take(20)
+                .map(|(id, _)| id)
+                .collect();
+            for id in new_ids {
+                if artist_seen.insert(id) {
+                    artist_ids.push(id);
                 }
             }
         }

--- a/src/services/search.rs
+++ b/src/services/search.rs
@@ -37,14 +37,14 @@ pub struct SearchResults {
 /// Strips FTS5 operator characters, then appends `*` to each token for prefix
 /// matching ("Coltr" → "Coltr*"). Returns empty string if nothing remains.
 fn sanitize_fts_query(raw: &str) -> String {
-    let cleaned: String = raw
-        .chars()
-        .map(|c| match c {
-            '"' | '(' | ')' | ':' | '^' | '-' | '*' | '\\' | '+' | '~' | '%' | '/' | '?'
-            | '.' => ' ',
-            _ => c,
-        })
-        .collect();
+    let cleaned: String =
+        raw.chars()
+            .map(|c| match c {
+                '"' | '(' | ')' | ':' | '^' | '-' | '*' | '\\' | '+' | '~' | '%' | '/' | '?'
+                | '.' => ' ',
+                _ => c,
+            })
+            .collect();
     cleaned
         .split_whitespace()
         .filter(|t| !t.is_empty())
@@ -69,8 +69,12 @@ fn levenshtein(a: &str, b: &str) -> usize {
     let a: Vec<char> = a.chars().collect();
     let b: Vec<char> = b.chars().collect();
     let (n, m) = (a.len(), b.len());
-    if n == 0 { return m; }
-    if m == 0 { return n; }
+    if n == 0 {
+        return m;
+    }
+    if m == 0 {
+        return n;
+    }
     let mut row: Vec<usize> = (0..=m).collect();
     for i in 1..=n {
         let mut prev = row[0];
@@ -104,18 +108,24 @@ fn edit_threshold(query_chars: usize) -> usize {
 /// 2. Every query word is a prefix of some candidate word.
 /// 3. Edit distance ≤ threshold (queries ≥ 4 chars only).
 pub fn fuzzy_matches(query: &str, candidate: &str) -> bool {
-    if query.is_empty() { return true; }
+    if query.is_empty() {
+        return true;
+    }
     let q = query.to_lowercase();
     let c = candidate.to_lowercase();
 
     // 1. Substring
-    if c.contains(&q) { return true; }
+    if c.contains(&q) {
+        return true;
+    }
 
     // 2. All query words appear as prefixes of some candidate word
     let q_words: Vec<&str> = q.split_whitespace().collect();
     let c_words: Vec<&str> = c.split_whitespace().collect();
     if !q_words.is_empty()
-        && q_words.iter().all(|qw| c_words.iter().any(|cw| cw.starts_with(qw)))
+        && q_words
+            .iter()
+            .all(|qw| c_words.iter().any(|cw| cw.starts_with(qw)))
     {
         return true;
     }
@@ -123,8 +133,12 @@ pub fn fuzzy_matches(query: &str, candidate: &str) -> bool {
     // 3. Levenshtein
     let threshold = edit_threshold(q.chars().count());
     if threshold > 0 {
-        if levenshtein(&q, &c) <= threshold { return true; }
-        if c_words.iter().any(|cw| levenshtein(&q, cw) <= threshold) { return true; }
+        if levenshtein(&q, &c) <= threshold {
+            return true;
+        }
+        if c_words.iter().any(|cw| levenshtein(&q, cw) <= threshold) {
+            return true;
+        }
     }
 
     false
@@ -182,7 +196,9 @@ impl SearchService {
                     .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
                 {
                     for id in ids {
-                        if track_seen.insert(id) { track_ids.push(id); }
+                        if track_seen.insert(id) {
+                            track_ids.push(id);
+                        }
                     }
                 }
             }
@@ -202,7 +218,9 @@ impl SearchService {
                     .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
                 {
                     for id in ids {
-                        if track_seen.insert(id) { track_ids.push(id); }
+                        if track_seen.insert(id) {
+                            track_ids.push(id);
+                        }
                     }
                 }
             }
@@ -227,14 +245,15 @@ impl SearchService {
                     .filter_map(|r| r.ok())
                     .filter(|(id, title, artist)| {
                         !track_seen.contains(id)
-                            && (fuzzy_matches(&q_lower, title)
-                                || fuzzy_matches(&q_lower, artist))
+                            && (fuzzy_matches(&q_lower, title) || fuzzy_matches(&q_lower, artist))
                     })
                     .take(50)
                     .map(|(id, _, _)| id)
                     .collect();
                 for id in new_ids {
-                    if track_seen.insert(id) { track_ids.push(id); }
+                    if track_seen.insert(id) {
+                        track_ids.push(id);
+                    }
                 }
             }
         }
@@ -265,7 +284,9 @@ impl SearchService {
                     .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
                 {
                     for id in ids {
-                        if album_seen.insert(id) { album_ids.push(id); }
+                        if album_seen.insert(id) {
+                            album_ids.push(id);
+                        }
                     }
                 }
             }
@@ -285,7 +306,9 @@ impl SearchService {
                     .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
                 {
                     for id in ids {
-                        if album_seen.insert(id) { album_ids.push(id); }
+                        if album_seen.insert(id) {
+                            album_ids.push(id);
+                        }
                     }
                 }
             }
@@ -310,14 +333,15 @@ impl SearchService {
                     .filter_map(|r| r.ok())
                     .filter(|(id, title, artist)| {
                         !album_seen.contains(id)
-                            && (fuzzy_matches(&q_lower, title)
-                                || fuzzy_matches(&q_lower, artist))
+                            && (fuzzy_matches(&q_lower, title) || fuzzy_matches(&q_lower, artist))
                     })
                     .take(20)
                     .map(|(id, _, _)| id)
                     .collect();
                 for id in new_ids {
-                    if album_seen.insert(id) { album_ids.push(id); }
+                    if album_seen.insert(id) {
+                        album_ids.push(id);
+                    }
                 }
             }
         }
@@ -376,7 +400,9 @@ impl SearchService {
                     .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
                 {
                     for id in ids {
-                        if artist_seen.insert(id) { artist_ids.push(id); }
+                        if artist_seen.insert(id) {
+                            artist_ids.push(id);
+                        }
                     }
                 }
             }
@@ -384,15 +410,17 @@ impl SearchService {
 
         // 2. LIKE substring
         if !like_q.is_empty() {
-            if let Ok(mut stmt) = conn.prepare(
-                "SELECT id FROM artists WHERE name LIKE '%' || ?1 || '%' LIMIT 20",
-            ) {
+            if let Ok(mut stmt) =
+                conn.prepare("SELECT id FROM artists WHERE name LIKE '%' || ?1 || '%' LIMIT 20")
+            {
                 if let Ok(ids) = stmt
                     .query_map([&like_q], |row| row.get(0))
                     .and_then(|rows| rows.collect::<rusqlite::Result<Vec<i64>>>())
                 {
                     for id in ids {
-                        if artist_seen.insert(id) { artist_ids.push(id); }
+                        if artist_seen.insert(id) {
+                            artist_ids.push(id);
+                        }
                     }
                 }
             }
@@ -407,14 +435,14 @@ impl SearchService {
                     })
                     .map_err(LibraryError::Database)?
                     .filter_map(|r| r.ok())
-                    .filter(|(id, name)| {
-                        !artist_seen.contains(id) && fuzzy_matches(&q_lower, name)
-                    })
+                    .filter(|(id, name)| !artist_seen.contains(id) && fuzzy_matches(&q_lower, name))
                     .take(20)
                     .map(|(id, _)| id)
                     .collect();
                 for id in new_ids {
-                    if artist_seen.insert(id) { artist_ids.push(id); }
+                    if artist_seen.insert(id) {
+                        artist_ids.push(id);
+                    }
                 }
             }
         }
@@ -426,7 +454,8 @@ impl SearchService {
             .filter_map(|&id| {
                 conn.query_row(
                     "SELECT id, name, name_sort, bio, country, genre, style, mood,
-                        formed_year, born_year, died_year, disbanded, musicbrainz_id, theaudiodb_id
+                        formed_year, born_year, died_year, disbanded, musicbrainz_id,
+                        theaudiodb_id, photo_path
                      FROM artists WHERE id = ?1",
                     rusqlite::params![id],
                     |row| {
@@ -445,6 +474,9 @@ impl SearchService {
                             disbanded: row.get(11)?,
                             musicbrainz_id: row.get(12)?,
                             theaudiodb_id: row.get(13)?,
+                            photo_path: row
+                                .get::<_, Option<String>>(14)?
+                                .map(std::path::PathBuf::from),
                         })
                     },
                 )
@@ -452,7 +484,11 @@ impl SearchService {
             })
             .collect();
 
-        Ok(SearchResults { tracks, albums, artists })
+        Ok(SearchResults {
+            tracks,
+            albums,
+            artists,
+        })
     }
 }
 
@@ -644,7 +680,10 @@ mod tests {
         env.seed_basic_library();
         let service = SearchService::new(env.pool.clone());
         let results = service.search("Track").unwrap();
-        assert!(!results.tracks.is_empty(), "must find tracks by title token");
+        assert!(
+            !results.tracks.is_empty(),
+            "must find tracks by title token"
+        );
     }
 
     #[test]
@@ -653,7 +692,11 @@ mod tests {
         env.seed_basic_library();
         let service = SearchService::new(env.pool.clone());
         let results = service.search("One").unwrap();
-        assert_eq!(results.tracks.len(), 1, "only 'Track One' contains token 'One'");
+        assert_eq!(
+            results.tracks.len(),
+            1,
+            "only 'Track One' contains token 'One'"
+        );
         assert_eq!(results.tracks[0].title, "Track One");
     }
 
@@ -663,7 +706,10 @@ mod tests {
         env.seed_basic_library();
         let service = SearchService::new(env.pool.clone());
         let results = service.search("Artist").unwrap();
-        assert!(!results.tracks.is_empty(), "must find tracks by artist name token");
+        assert!(
+            !results.tracks.is_empty(),
+            "must find tracks by artist name token"
+        );
     }
 
     #[test]
@@ -672,7 +718,10 @@ mod tests {
         env.seed_basic_library();
         let service = SearchService::new(env.pool.clone());
         let results = service.search("Trac").unwrap();
-        assert!(!results.tracks.is_empty(), "prefix 'Trac' must find 'Track One'");
+        assert!(
+            !results.tracks.is_empty(),
+            "prefix 'Trac' must find 'Track One'"
+        );
     }
 
     #[test]
@@ -681,7 +730,10 @@ mod tests {
         env.seed_basic_library();
         let service = SearchService::new(env.pool.clone());
         let results = service.search("Test Al").unwrap();
-        assert!(!results.albums.is_empty(), "prefix must find album by partial title");
+        assert!(
+            !results.albums.is_empty(),
+            "prefix must find album by partial title"
+        );
     }
 
     #[test]
@@ -690,7 +742,10 @@ mod tests {
         env.seed_basic_library();
         let service = SearchService::new(env.pool.clone());
         let results = service.search("Test Art").unwrap();
-        assert!(!results.artists.is_empty(), "prefix must find artist by partial name");
+        assert!(
+            !results.artists.is_empty(),
+            "prefix must find artist by partial name"
+        );
     }
 
     /// Regression: a track absent from tracks_fts must still appear via LIKE.
@@ -731,7 +786,10 @@ mod tests {
         let service = SearchService::new(env.pool.clone());
         // "Trak" is 1 edit from "Track" — Levenshtein must find it
         let results = service.search("Trak").unwrap();
-        assert!(!results.tracks.is_empty(), "Levenshtein must find 'Track One' with 'Trak'");
+        assert!(
+            !results.tracks.is_empty(),
+            "Levenshtein must find 'Track One' with 'Trak'"
+        );
     }
 
     #[test]
@@ -741,7 +799,10 @@ mod tests {
         let service = SearchService::new(env.pool.clone());
         // "Test Artst" is 1 edit from "Test Artist"
         let results = service.search("Test Artst").unwrap();
-        assert!(!results.artists.is_empty(), "Levenshtein must find 'Test Artist' with 'Test Artst'");
+        assert!(
+            !results.artists.is_empty(),
+            "Levenshtein must find 'Test Artist' with 'Test Artst'"
+        );
     }
 
     // ── Special characters — must not panic ───────────────────────────────


### PR DESCRIPTION
## Summary

- `import_files` FFI now finds or creates a persistent **"Imported"** playlist after importing files
- All newly imported track IDs are added to that playlist
- `playlist_id` is returned in the JSON response so the GUI can navigate to it directly
- Replaced the old date-stamped per-import playlist design with a single reusable playlist

## Test plan

- [x] `test_import_files_valid_flac_creates_imported_playlist` - verifies playlist named "Imported" is created
- [x] `test_import_files_second_import_reuses_imported_playlist` - verifies second import reuses same playlist and accumulates tracks
- [x] `test_import_files_invalid_json_returns_error` - unchanged
- [x] `test_import_files_empty_array_returns_zero_tracks` - no playlist_id when 0 tracks
- [x] `test_import_files_nonexistent_paths_returns_zero` - no playlist_id when no tracks imported

Closes SINRA issue: Gestion d'import de fichiers (940ca11a-4c8b-4a06-ab30-163a436459f1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)